### PR TITLE
feat: support sqlite open v2

### DIFF
--- a/doc/sqlite.txt
+++ b/doc/sqlite.txt
@@ -1,5 +1,5 @@
 ================================================================================
-                                                                 *sqlite.readme*
+README                                                           *sqlite.readme*
 
 SQLite/LuaJIT binding and highly opinionated wrapper for storing, retrieving,
 caching, persisting, querying, and connecting to SQLite databases.
@@ -69,7 +69,7 @@ sqlite_db_status                                            *sqlite_db_status*
 
 
 ================================================================================
-                                                                 *sqlite.db.lua*
+LUA                                                              *sqlite.db.lua*
 
 Main sqlite.lua object and methods.
 
@@ -95,6 +95,9 @@ sqlite.db.new({uri}, {opts})                                 *sqlite.db.new()*
 
     ```lua
     local db = sqlite.new("path/to/db" or "$env_var", { ... } or nil)
+    -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+    -- for more customize behaviour, set opts.open_mode to a list of db.flags
+    -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
     ```
 
 
@@ -151,6 +154,9 @@ sqlite.db:open({uri}, {opts})                               *sqlite.db:open()*
     local db = sqlite.db:open("./pathto/dbfile" or "$ENV_VARABLE" or nil, {...})
     -- reopen connection if closed.
     db:open()
+    -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+    -- for more customize behaviour, set opts.open_mode to a list of db.flags
+    -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
     ```
 
 
@@ -511,7 +517,7 @@ sqlite.db.lib()                                              *sqlite.db.lib()*
 
 
 ================================================================================
-                                                                *sqlite.tbl.lua*
+LUA                                                             *sqlite.tbl.lua*
 
 Abstraction to produce more readable code.
 ```lua

--- a/lua/sqlite/db.lua
+++ b/lua/sqlite/db.lua
@@ -33,6 +33,9 @@ local tbl = require "sqlite.tbl"
 ---<pre>
 ---```lua
 --- local db = sqlite.new("path/to/db" or "$env_var", { ... } or nil)
+--- -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+--- -- for more customize behaviour, set opts.open_mode to a list of db.flags
+--- -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
 ---```
 ---</pre>
 ---@param uri string: uri to db file.
@@ -87,6 +90,9 @@ end
 ---   opts = {} or nil -- custom sqlite3 options, see |sqlite_opts|
 ---   --- if opts.keep_open, make connection and keep it open.
 ---   --- if opts.lazy, then just provide logical object
+---   --- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+---   --- for more customize behaviour, set opts.open_mode to a list of db.flags
+---   --- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
 --- }
 --- --- Overwrite method and access it using through pre-appending "__"
 --- db.select = function(...) db:__select(...) end
@@ -138,6 +144,9 @@ end
 --- local db = sqlite.db:open("./pathto/dbfile" or "$ENV_VARABLE" or nil, {...})
 --- -- reopen connection if closed.
 --- db:open()
+--- -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+--- -- for more customize behaviour, set opts.open_mode to a list of db.flags
+--- -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
 ---```
 ---</pre>
 ---@param uri string: (optional) {uri} == {nil} then in-memory db.
@@ -649,5 +658,7 @@ sqlite.db.lib = require "sqlite.strfun"
 sqlite.db = setmetatable(sqlite.db, {
   __call = sqlite.db.extend,
 })
+
+sqlite.db.flags = clib.flags
 
 return sqlite.db

--- a/lua/sqlite/defs.lua
+++ b/lua/sqlite/defs.lua
@@ -653,18 +653,32 @@ M.last_errcode = function(conn_ptr)
   return clib.sqlite3_errcode(conn_ptr)
 end
 
+-- Open Modes
+M.open_modes = {
+  ["ro"] = bit.bor(M.flags.open_readonly, M.flags.open_uri),
+  ["rw"] = bit.bor(M.flags.open_readwrite, M.flags.open_uri),
+  ["rwc"] = bit.bor(M.flags.open_readwrite, M.flags.open_create, M.flags.open_uri),
+}
+
 ---Create new connection and modify `sqlite_db` object
 ---@param uri string
 ---@param opts sqlite_db.opts
 ---@return sqlite_blob*
----@TODO: support open_v2 to enable control over how the database file is opened.
 M.connect = function(uri, opts)
   opts = opts or {}
   local conn = M.get_new_db_ptr()
-  local code = clib.sqlite3_open(uri, conn)
+  local open_mode = opts.open_mode
+  opts.open_mode = nil
+  if type(open_mode) == "table" then
+    open_mode = bit.bor(unpack(open_mode))
+  else
+    open_mode = M.open_modes[open_mode or "rwc"]
+  end
+
+  local code = clib.sqlite3_open_v2(uri, conn, open_mode, nil)
 
   if code ~= M.flags.ok then
-    error(("sqlite.lua: couldn't connect to sql database, ERR:"):format(code))
+    error(("sqlite.lua: couldn't connect to sql database, ERR: %s"):format(M.last_errmsg(conn[0])))
   end
 
   for k, v in pairs(opts) do

--- a/lua/sqlite/examples/bookmarks.lua
+++ b/lua/sqlite/examples/bookmarks.lua
@@ -25,7 +25,6 @@ local julianday, strftime = sqlite.lib.julianday, sqlite.lib.strftime
 
 ---@alias BMType '"web"' | '"file"' | '"dir"'
 
-
 --[[ Datashapes ---------------------------------------------
 
 ---@class BMCollection
@@ -160,7 +159,7 @@ function entries:inc(id)
   local row = entries:where { id = id }
   entries:update {
     where = { id = id },
-    set = { count = row.count + 1 }
+    set = { count = row.count + 1 },
   }
   ts:insert(id)
   ts:trim(id)
@@ -169,7 +168,6 @@ end
 ---Add a row
 ---@param row BMEntry
 function entries:add(row)
-
   if row.collection and not collection:where { title = row.collection } then
     collection:insert { title = row.collection }
   end
@@ -271,7 +269,6 @@ end
 if entries:count() == 0 then
   entries:seed()
 end
-
 
 ---Edit an entry --- simple abstraction over entries.update { where = {id = 3}, set = { title = "none" } }
 entries:edit(3, { title = "none" })


### PR DESCRIPTION
### Purpose

Enable users to control how should the sqlite database opened via opts.open_mode, while enabling support for uri processing https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open

- [ ] Fix docgen
- [x] Fix tests of fields types

Fix #131