### PR TITLE
add shared lib path for ubuntu

### DIFF
--- a/lua/sqlite/defs.lua
+++ b/lua/sqlite/defs.lua
@@ -35,6 +35,7 @@ local clib = (function()
       if os.sysname == "Linux" then
         local linux_paths = {
           "/usr/lib/x86_64-linux-gnu/libsqlite3.so",
+          "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0",
           "/usr/lib64/libsqlite3.so",
           "/usr/lib/libsqlite3.so",
         }


### PR DESCRIPTION
```
$ dpkg -L libsqlite3-0 | grep libsqlite3.so
/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6
/usr/lib/x86_64-linux-gnu/libsqlite3.so.0
```