### PR TITLE
chore/update-readme-fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ luarocks install sqlite luv
 ```bash
 sudo pacman -S sqlite # Arch
 sudo apt-get install sqlite3 libsqlite3-dev # Ubuntu
+sudo dnf install sqlite sqlite-devel # Fedora
 ```
 
 #### Nix (home-manager)


### PR DESCRIPTION
sudo dnf install sqlite sqlite-devel without devel the .so libs are not found and some plugins using sqlite will error out.