### PR TITLE
docs: Add instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ luarocks install sqlite luv
 ```bash
 sudo pacman -S sqlite # Arch
 sudo apt-get install sqlite3 libsqlite3-dev # Ubuntu
+sudo dnf install sqlite sqlite-devel # Fedora
 ```
 
 #### Nix (home-manager)


### PR DESCRIPTION
I fumbled a bit with setting this up on Fedora since the packages are named different, so I think we should document this for Fedora like with Ubuntu.