### PR TITLE
revise(defs): add libsqlite3.so.0 to lookup

### DIFF
--- a/lua/sqlite/defs.lua
+++ b/lua/sqlite/defs.lua
@@ -37,6 +37,7 @@ local clib = (function()
           "/usr/lib/x86_64-linux-gnu/libsqlite3.so",
           "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0",
           "/usr/lib64/libsqlite3.so",
+          "/usr/lib64/libsqlite3.so.0",
           "/usr/lib/libsqlite3.so",
         }
         for _, v in pairs(linux_paths) do


### PR DESCRIPTION
On my Fedora 39 machine, the package crashed when used in combination with `yanky.nvim` because it couldn't find the path to the sqlite3 lib. After some debugging I found a `.0` missing from the path in the `linux_paths` list.

This miniscule PR fixes this bug by simply adding the path.