### PR TITLE
chore(utils):  handle ~ appearing in middle of path

### DIFF
--- a/lua/sqlite/utils.lua
+++ b/lua/sqlite/utils.lua
@@ -100,7 +100,7 @@ end)()
 
 M.expand = function(path)
   local expanded
-  if string.find(path, "~") then
+  if string.find(path, "^~") then
     expanded = string.gsub(path, "^~", os.getenv "HOME")
   elseif string.find(path, "^%.") then
     expanded = luv.fs_realpath(path)


### PR DESCRIPTION
In Windows OS, `~` may appear inside a path (not at the beginning). So only replace `~` by `$HOME` if `~` is at the very beginning of the path.
It is more consistent with the `string.gsub` on next line.