### PR TITLE
Use HOMEBREW_PREFIX in defs.lua

### DIFF
--- a/lua/sqlite/defs.lua
+++ b/lua/sqlite/defs.lua
@@ -51,7 +51,6 @@ local clib = (function()
         local homebrew_prefix = luv.os_getenv "HOMEBREW_PREFIX" or "/opt/homebrew"
         return os.machine == "arm64" and homebrew_prefix .. "/opt/sqlite/lib/libsqlite3.dylib"
           or "/usr/local/opt/sqlite3/lib/libsqlite3.dylib"
-
       end
     end)()
 

--- a/lua/sqlite/defs.lua
+++ b/lua/sqlite/defs.lua
@@ -48,8 +48,10 @@ local clib = (function()
       end
 
       if os.sysname == "Darwin" then
-        return os.machine == "arm64" and "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib"
+        local homebrew_prefix = luv.os_getenv "HOMEBREW_PREFIX" or "/opt/homebrew"
+        return os.machine == "arm64" and homebrew_prefix .. "/opt/sqlite/lib/libsqlite3.dylib"
           or "/usr/local/opt/sqlite3/lib/libsqlite3.dylib"
+
       end
     end)()
 


### PR DESCRIPTION
Some people install brew in another directory and have the HOMEBREW_PREFIX env variable set.

Use it or fallback to the default path.